### PR TITLE
✨ electron-store 적용, TODAY 버튼 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2673,7 +2673,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -3188,6 +3188,32 @@
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -3196,7 +3222,7 @@
     "alphanum-sort": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-      "integrity": "sha512-0FcBfdcmaumGPQ0qPn7Q5qTgz/ooXgIyp1rf8ik5bGX8mpE2YHjC0P/eyQvxu1GURYQgq9ozf2mteQ5ZD9YiyQ=="
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -3221,7 +3247,7 @@
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha512-JoAxEa1DfP9m2xfB/y2r/aKcwXNlltr4+0QSBC4TrLfcxyvepX2Pv0t/xpgGV5bGsDzCYV8SzjWgyCW0T9yYbA=="
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -3270,12 +3296,12 @@
     "arity-n": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
-      "integrity": "sha512-fExL2kFDC1Q2DUOx3whE/9KoN66IzkY4b4zUHUBFM1ojEYjZZYDcUW3bek/ufGionX9giIKDC5redH2IlGqcQQ=="
+      "integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
     },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA=="
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -3285,7 +3311,7 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-flatten": {
       "version": "2.1.2",
@@ -3312,12 +3338,12 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q=="
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ=="
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
       "version": "1.3.0",
@@ -3361,7 +3387,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -3408,12 +3434,12 @@
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -3441,7 +3467,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -3452,6 +3478,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
     },
     "autoprefixer": {
       "version": "9.8.8",
@@ -3696,12 +3727,12 @@
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha512-C4Aq+GaAj83pRQ0EFgTvw5YO6T3Qz2KGrNRwIj9mSoNHVvdZY4KO2uA6HNtNXCw993iSZnckY1aLW8nOi8i4+w=="
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha512-ocgA9VJvyxwt+qJB0ncxV8kb/CjfTcECUY4tQ5VT7nP6Aohzobm8CDFaQ5FHdvZQzLmf0sgDxB8iRXZXxwZcyA==",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
         "babel-plugin-syntax-object-rest-spread": "^6.8.0",
         "babel-runtime": "^6.26.0"
@@ -3817,7 +3848,7 @@
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -3903,7 +3934,7 @@
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "bfj": {
       "version": "7.0.2",
@@ -3988,7 +4019,7 @@
     "bonjour": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-      "integrity": "sha512-RaVTblr+OnEli0r/ud8InrU7D+G0y6aJhlxaLa6Pwty4+xoxboF1BsUI45tujvRpbj9dQVoglChqonGAsjEBYg==",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
         "array-flatten": "^2.1.0",
         "deep-equal": "^1.0.1",
@@ -4001,7 +4032,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boolean": {
       "version": "3.2.0",
@@ -4030,7 +4061,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -4154,7 +4185,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-from": {
@@ -4170,7 +4201,7 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-modules": {
       "version": "3.3.0",
@@ -4180,12 +4211,12 @@
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
       "version": "15.3.0",
@@ -4285,7 +4316,7 @@
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
         "callsites": "^2.0.0"
       },
@@ -4293,14 +4324,14 @@
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ=="
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
         }
       }
     },
     "caller-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -4775,6 +4806,57 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
+        }
+      }
+    },
+    "conf": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.1.2.tgz",
+      "integrity": "sha512-o9Fv1Mv+6A0JpoayQ8JleNp3hhkbOJP/Re/Q+QqxMPHPkABVsRjQGWZn9A5GcqLiTNC6d89p2PB5ZhHVDSMwyg==",
+      "requires": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "dot-prop": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+          "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -5345,6 +5427,21 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
+    "debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "requires": {
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
+        }
+      }
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5483,7 +5580,7 @@
         "array-union": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "requires": {
             "array-uniq": "^1.0.1"
           }
@@ -5827,6 +5924,22 @@
         }
       }
     },
+    "electron-store": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.1.tgz",
+      "integrity": "sha512-ZyLvNywiqSpbwC/pp89O/AycVWY/UJIkmtyzF2Bd0Nm/rLmcFc0NTGuLdg6+LE8mS8qsiK5JMoe4PnrecLHH5w==",
+      "requires": {
+        "conf": "^10.0.3",
+        "type-fest": "^1.0.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.137",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
@@ -5918,8 +6031,7 @@
     "env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "errno": {
       "version": "0.1.8",
@@ -10232,6 +10344,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -13531,7 +13648,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "css-select": {
           "version": "4.3.0",
@@ -16497,7 +16614,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "anymatch": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mui/x-data-grid": "^4.0.1",
     "active-win": "^7.7.1",
     "date-fns": "^2.28.0",
+    "electron-store": "^8.0.1",
     "extract-file-icon": "^0.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/public/electron.js
+++ b/public/electron.js
@@ -65,6 +65,13 @@ app.whenReady().then(() => {
     }
   });
 
+  ipcMain.on('STOP_ACTIVE_WINDOW', async (event) => {
+    trackWindowStore.endTrackingWindow();
+
+    const activeWindows = trackWindowStore.findTrackWindowBySelectedDay();
+    event.reply('REPLY_ACTIVE_WINDOW', { activeWindows });
+  });
+
   win.once('ready-to-show', () => win.show());
   win.on('closed', () => {
     win = null;
@@ -78,4 +85,8 @@ app.whenReady().then(() => {
 
 app.on('window-all-closed', () => {
   app.quit();
+});
+
+app.on('quit', () => {
+  trackWindowStore.endTrackingWindow();
 });

--- a/public/electron.js
+++ b/public/electron.js
@@ -26,8 +26,8 @@ app.whenReady().then(() => {
   ipcMain.on('SELECTEDDAY_WINDOW', (event, payload) => {
     trackWindowStore.setSelectedDay(payload);
 
-    const activeWindows = trackWindowStore.findTrackWindowBySelectedDay();
-    event.reply('REPLY_ACTIVE_WINDOW', { activeWindows });
+    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+    event.reply('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
   });
 
   ipcMain.on('ACTIVE_WINDOW', async (event) => {
@@ -39,7 +39,7 @@ app.whenReady().then(() => {
       owner: { name, processId, path },
     } = window;
 
-    const processedWindow = {
+    const newActiveWin = {
       id,
       title,
       processId,
@@ -52,29 +52,29 @@ app.whenReady().then(() => {
 
     trackWindowStore.getStore();
 
-    if (trackWindowStore.isNewTrackWindow(processedWindow)) {
+    if (trackWindowStore.isNewTrackWindow(newActiveWin)) {
       if (trackWindowStore.hasCurrentWindow()) {
-        trackWindowStore.setCurrentActiveWinFinishedDate(processedWindow.startDate);
+        trackWindowStore.setCurrentActiveWinFinishedDate(newActiveWin.startDate);
       }
-      trackWindowStore.setNewTrackWindow(processedWindow);
+      trackWindowStore.setNewTrackWindow(newActiveWin);
     }
 
     if (trackWindowStore.isSelectedDayToday()) {
-      const activeWindows = trackWindowStore.findTrackWindowBySelectedDay();
-      event.reply('REPLY_ACTIVE_WINDOW', { processedWindow, activeWindows });
+      const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+      event.reply('REPLY_ACTIVE_WINDOW', { newActiveWin, allDayTrackWindows });
     }
   });
 
   ipcMain.on('STOP_ACTIVE_WINDOW', async (event) => {
     trackWindowStore.endTrackingWindow();
 
-    const activeWindows = trackWindowStore.findTrackWindowBySelectedDay();
-    event.reply('REPLY_ACTIVE_WINDOW', { activeWindows });
+    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+    event.reply('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
   });
 
   win.webContents.on('did-finish-load', () => {
-    const activeWindows = trackWindowStore.findTrackWindowBySelectedDay();
-    win.webContents.send('REPLY_ACTIVE_WINDOW', { activeWindows });
+    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+    win.webContents.send('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
   });
 
   win.once('ready-to-show', () => win.show());

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,12 +1,13 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');
+const { format, intervalToDuration, formatDuration } = require('date-fns');
 const formatDistanceStrict = require('date-fns/formatDistanceStrict');
+const Store = require('electron-store');
+const activeWin = require('active-win');
 const { storeAppIcon } = require('./utils/icon');
-//require('devtron').install();
 
-const activeWindows = [];
-let currentActiveWin;
+const store = new Store();
 
 app.whenReady().then(() => {
   let win = new BrowserWindow({
@@ -27,8 +28,11 @@ app.whenReady().then(() => {
   }
 
   ipcMain.on('ACTIVE_WINDOW', async (event, payload) => {
-    const activeWin = require('active-win');
     let window = await activeWin({ screenRecordingPermission: true });
+
+    //* store에는 "trackWindows"와 "currentActiveWin"이 저장되어 있음
+    const trackWindows = store.get('trackWindows') || [];
+    const currentActiveWin = store.get('currentActiveWin') || null;
 
     const {
       id,
@@ -50,23 +54,27 @@ app.whenReady().then(() => {
     };
 
     //* 첫 할당이거나 활성 프로그램이 변했으면 재할당
-    //TODO 아무 프로그램도 활성화되어 있지 않을 때 (=바탕화면에 포커스가 잡혀있는 경우)
     if (!currentActiveWin || currentActiveWin.id !== processedWindow.id) {
-      //* 날짜 객체 생성해서 차이 구하기
-      const startedDate = currentActiveWin ? currentActiveWin.startDate : processedWindow.startDate;
-      const finishedDate = processedWindow.startDate;
-
-      const distance = formatDistanceStrict(startedDate, finishedDate, {
-        unit: 'second',
-      });
-
+      //* 활성 프로그램이 바꼈으면 이전 프로그램 정보에 finishedDate 정보 추가해서 store에 저장
       if (currentActiveWin) {
-        [currentActiveWin.finishedDate, currentActiveWin.distance] = [finishedDate, distance];
-      }
+        //* 날짜 객체 생성해서 차이 구하기
+        const { startDate } = currentActiveWin;
+        const { startDate: finishedDate } = processedWindow;
+        const distance = getDistanceDate(startDate, finishedDate);
 
-      currentActiveWin = processedWindow;
-      activeWindows.push(processedWindow);
+        //* 이전의 active-win 객체에 finishedDate와 distance 정보 업데이트
+        trackWindows.forEach((w) => {
+          if (w.id === currentActiveWin.id && w.startDate === currentActiveWin.startDate) {
+            [w.finishedDate, w.distance] = [finishedDate, distance];
+          }
+        });
+      }
+      trackWindows.push(processedWindow);
+      store.set('trackWindows', trackWindows);
+      store.set('currentActiveWin', processedWindow);
     }
+
+    const activeWindows = findTrackWindowByDate(new Date());
 
     event.reply('REPLY_ACTIVE_WINDOW', { processedWindow, activeWindows });
   });
@@ -85,3 +93,47 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   app.quit();
 });
+
+const findTrackWindowByDate = (comparedDate) => {
+  comparedDate = typeof date === 'string' ? new Date(comparedDate) : comparedDate;
+  const filtered = store
+    .get('trackWindows')
+    .filter(
+      (w) => format(new Date(w.startDate), 'yyyy-MM-dd') === format(comparedDate, 'yyyy-MM-dd'),
+    );
+
+  filtered.forEach(
+    (w) =>
+      ([w.startDate, w.finishedDate] = [
+        new Date(w.startDate),
+        w.finishedDate ? new Date(w.finishedDate) : null,
+      ]),
+  );
+
+  return filtered;
+};
+
+const getDistanceDate = (baseDate, comparedDate) => {
+  const formatDistanceLocale = {
+    xSeconds: (count) => `${count}sec`,
+    xMinutes: (count) => `${count}min`,
+    xHours: (count) => `${count}hour`,
+  };
+
+  const shortLocale = {
+    formatDistance: (token, count) => formatDistanceLocale[token](count),
+  };
+
+  const seconds = parseInt(
+    formatDistanceStrict(new Date(baseDate), new Date(comparedDate), {
+      unit: 'second',
+    }),
+  );
+  const duration = intervalToDuration({ start: 0, end: seconds * 1000 });
+  const distance = formatDuration(duration, {
+    format: ['hours', 'minutes', 'seconds'],
+    locale: shortLocale,
+  });
+
+  return distance;
+};

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,91 +1,16 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
-const path = require('path');
-const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');
-const activeWin = require('active-win');
-const { storeAppIcon } = require('./utils/icon');
-const { trackWindowStore } = require('./store/TrackWindowStore.js');
+const { app } = require('electron');
+const { trackWindowStore } = require('./store/TrackWindowStore');
+const { windowManager } = require('./utils/window-manager');
+const { ipcManager } = require('./utils/ipc-manager');
+const { extensionsManager } = require('./utils/extensions-manager');
 
-app.whenReady().then(() => {
-  let win = new BrowserWindow({
-    show: false,
-    width: 960,
-    height: 540,
-    webPreferences: {
-      enableRemoteModule: true,
-      preload: `${__dirname}/preload.js`,
-    },
-  });
+app.whenReady().then(async () => {
+  windowManager.createWindow();
+  ipcManager.init();
+
   if (process.env.mode === 'dev') {
-    win.loadURL('http://localhost:3000');
-    win.webContents.openDevTools();
-  } else {
-    // win.loadURL(`file://${path.join(__dirname, '../build/index.html')}`)
-    win.loadFile(`${path.join(__dirname, '../build/index.html')}`);
+    await extensionsManager.init();
   }
-
-  ipcMain.on('SELECTEDDAY_WINDOW', (event, payload) => {
-    trackWindowStore.setSelectedDay(payload);
-
-    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
-    event.reply('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
-  });
-
-  ipcMain.on('ACTIVE_WINDOW', async (event) => {
-    const window = await activeWin({ screenRecordingPermission: true });
-    const {
-      id,
-      title,
-      url,
-      owner: { name, processId, path },
-    } = window;
-
-    const newActiveWin = {
-      id,
-      title,
-      processId,
-      name,
-      url: url,
-      startDate: new Date(),
-    };
-
-    storeAppIcon(name, path); // 앱 아이콘 저장
-
-    trackWindowStore.getStore();
-
-    if (trackWindowStore.isNewTrackWindow(newActiveWin)) {
-      if (trackWindowStore.hasCurrentWindow()) {
-        trackWindowStore.setCurrentActiveWinFinishedDate(newActiveWin.startDate);
-      }
-      trackWindowStore.setNewTrackWindow(newActiveWin);
-    }
-
-    if (trackWindowStore.isSelectedDayToday()) {
-      const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
-      event.reply('REPLY_ACTIVE_WINDOW', { newActiveWin, allDayTrackWindows });
-    }
-  });
-
-  ipcMain.on('STOP_ACTIVE_WINDOW', async (event) => {
-    trackWindowStore.endTrackingWindow();
-
-    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
-    event.reply('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
-  });
-
-  win.webContents.on('did-finish-load', () => {
-    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
-    win.webContents.send('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
-  });
-
-  win.once('ready-to-show', () => win.show());
-  win.on('closed', () => {
-    win = null;
-  });
-
-  //react developer tools extension 추가
-  installExtension(REACT_DEVELOPER_TOOLS)
-    .then((name) => console.log(`Added Extension:  ${name}`))
-    .catch((err) => console.log('An error occurred: ', err));
 });
 
 app.on('window-all-closed', () => {

--- a/public/electron.js
+++ b/public/electron.js
@@ -72,6 +72,11 @@ app.whenReady().then(() => {
     event.reply('REPLY_ACTIVE_WINDOW', { activeWindows });
   });
 
+  win.webContents.on('did-finish-load', () => {
+    const activeWindows = trackWindowStore.findTrackWindowBySelectedDay();
+    win.webContents.send('REPLY_ACTIVE_WINDOW', { activeWindows });
+  });
+
   win.once('ready-to-show', () => win.show());
   win.on('closed', () => {
     win = null;

--- a/public/electron.js
+++ b/public/electron.js
@@ -29,24 +29,18 @@ app.whenReady().then(() => {
   }
 
   ipcMain.on('SELECTEDDAY_WINDOW', (event, payload) => {
-    //TODO 1. 오늘 목록만 저장할 변수? 관리하기 / 오늘 목록인지 확인할 변수도 필요함
-    //TODO 2. 이전/다음 날짜로 넘어갔을 때 선택한 날짜가 오늘이 아니면 리스트는 더 이상 업데이트 하지 않아야 함
-    //TODO 2-1. 추적중인 경우(start 버튼이 클릭된 경우)에 현재 추척 목록은 저장하되 리스트는 더 이상 업데이트 하지 않아야 하고
-    //TODO 2-2. 오늘 목록으로 넘어오면 따로 저장해둔 목록을 불러와야 함
-
     isSelectedDayToday = payload === format(new Date(), 'yyyy-MM-dd');
 
     const activeWindows = findTrackWindowByDate(payload);
     event.reply('REPLY_ACTIVE_WINDOW', { activeWindows });
   });
 
-  ipcMain.on('ACTIVE_WINDOW', async (event, payload) => {
-    let window = await activeWin({ screenRecordingPermission: true });
-
+  ipcMain.on('ACTIVE_WINDOW', async (event) => {
     //* store에는 "trackWindows"와 "currentActiveWin"이 저장되어 있음
     const trackWindows = store.get('trackWindows') || [];
     const currentActiveWin = store.get('currentActiveWin') || null;
 
+    const window = await activeWin({ screenRecordingPermission: true });
     const {
       id,
       title,
@@ -67,17 +61,15 @@ app.whenReady().then(() => {
     };
 
     //* 첫 할당이거나 활성 프로그램이 변했으면 재할당
-    if (!currentActiveWin || currentActiveWin.id !== processedWindow.id) {
-      //* 활성 프로그램이 바꼈으면 이전 프로그램 정보에 finishedDate 정보 추가해서 store에 저장
+    if (!currentActiveWin || !isSameWindow(currentActiveWin, processedWindow)) {
       if (currentActiveWin) {
-        //* 날짜 객체 생성해서 차이 구하기
         const { startDate } = currentActiveWin;
         const { startDate: finishedDate } = processedWindow;
         const distance = getDistanceDate(startDate, finishedDate);
 
-        //* 이전의 active-win 객체에 finishedDate와 distance 정보 업데이트
+        //* 활성 프로그램이 바꼈으면 이전의 active-win 객체에 finishedDate와 distance 정보 업데이트
         trackWindows.forEach((w) => {
-          if (w.id === currentActiveWin.id && w.startDate === currentActiveWin.startDate) {
+          if (isSameWindow(w, currentActiveWin) && w.startDate === currentActiveWin.startDate) {
             [w.finishedDate, w.distance] = [finishedDate, distance];
           }
         });
@@ -108,6 +100,14 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   app.quit();
 });
+
+const isSameWindow = (item1, item2) => {
+  if (item1 && item2 && item1.app === item2.app && item1.title === item2.title) {
+    return true;
+  }
+
+  return false;
+};
 
 const findTrackWindowByDate = (comparedDate) => {
   comparedDate = typeof comparedDate === 'string' ? new Date(comparedDate) : comparedDate;

--- a/public/store/TrackWindowStore.js
+++ b/public/store/TrackWindowStore.js
@@ -1,0 +1,105 @@
+const { getDistanceDate } = require('../utils/dateFormat.js');
+const Store = require('electron-store');
+const { format } = require('date-fns');
+
+class TrackWindowStore {
+  #store = new Store();
+  #selectedDay = format(new Date(), 'yyyy-MM-dd');
+  #trackWindows = [];
+  #currentActiveWin = null;
+
+  constructor() {
+    this.getStore();
+  }
+
+  getStore = () => {
+    this.#trackWindows = (this.#store.get('trackWindows') || []).map((w) => {
+      [w.startDate, w.finishedDate] = [
+        new Date(w.startDate),
+        w.finishedDate ? new Date(w.finishedDate) : null,
+      ];
+
+      return w;
+    });
+    this.#currentActiveWin = this.#store.get('currentActiveWin') || null;
+  };
+
+  setStore = () => {
+    this.#store.set('trackWindows', this.#trackWindows);
+    this.#store.set('currentActiveWin', this.#currentActiveWin);
+  };
+
+  setSelectedDay = (date) => {
+    this.#selectedDay = date;
+  };
+
+  isSelectedDayToday = () => {
+    return this.#selectedDay === format(new Date(), 'yyyy-MM-dd');
+  };
+
+  addTrackWindows = (window) => {
+    this.#trackWindows.push(window);
+  };
+
+  setCurrentActiveWin = (newActiveWin) => {
+    this.#currentActiveWin = newActiveWin;
+  };
+
+  deleteCurrentActiveWin = () => {
+    this.#currentActiveWin = null;
+    this.#store.delete('currentActiveWin');
+  };
+
+  setNewTrackWindow = (newWindow) => {
+    this.addTrackWindows(newWindow);
+    this.setCurrentActiveWin(newWindow);
+    this.setStore();
+  };
+
+  hasCurrentWindow = () => {
+    if (this.#currentActiveWin) {
+      return true;
+    }
+
+    return false;
+  };
+
+  isSameWindowAsCurrentActiveWin = (comparedWindow) => {
+    return this.isSameWindow(this.#currentActiveWin, comparedWindow);
+  };
+
+  isNewTrackWindow = (newWindow) => {
+    return !this.hasCurrentWindow() || !this.isSameWindowAsCurrentActiveWin(newWindow);
+  };
+
+  isSameWindow = (window1, window2) => {
+    if (window1 && window2 && window1.app === window2.app && window1.title === window2.title) {
+      return true;
+    }
+
+    return false;
+  };
+
+  findTrackWindowBySelectedDay = () => {
+    const filtered = this.#trackWindows.filter(
+      (w) => this.#selectedDay === format(w.startDate, 'yyyy-MM-dd'),
+    );
+    return filtered;
+  };
+
+  setCurrentActiveWinFinishedDate = (finishedDate) => {
+    const { startDate } = this.#currentActiveWin;
+
+    //* 활성 프로그램이 바꼈으면 이전의 active-win 객체에 finishedDate와 distance 정보 업데이트
+    this.#trackWindows.forEach((w) => {
+      if (
+        this.isSameWindow(w, this.#currentActiveWin) &&
+        JSON.stringify(w.startDate) === JSON.stringify(startDate)
+      ) {
+        [w.finishedDate, w.distance] = [finishedDate, getDistanceDate(startDate, finishedDate)];
+      }
+    });
+  };
+}
+
+module.exports.trackWindowStore = new TrackWindowStore();

--- a/public/store/TrackWindowStore.js
+++ b/public/store/TrackWindowStore.js
@@ -100,6 +100,14 @@ class TrackWindowStore {
       }
     });
   };
+
+  endTrackingWindow = () => {
+    if (this.hasCurrentWindow()) {
+      this.setCurrentActiveWinFinishedDate(new Date());
+      this.setStore();
+    }
+    this.deleteCurrentActiveWin();
+  };
 }
 
 module.exports.trackWindowStore = new TrackWindowStore();

--- a/public/store/TrackWindowStore.js
+++ b/public/store/TrackWindowStore.js
@@ -53,7 +53,6 @@ class TrackWindowStore {
   setNewTrackWindow = (newWindow) => {
     this.addTrackWindows(newWindow);
     this.setCurrentActiveWin(newWindow);
-    this.setStore();
   };
 
   hasCurrentWindow = () => {

--- a/public/utils/dateFormat.js
+++ b/public/utils/dateFormat.js
@@ -3,9 +3,9 @@ const formatDistanceStrict = require('date-fns/formatDistanceStrict');
 
 module.exports.getDistanceDate = (startDate, finishedDate) => {
   const formatDistanceLocale = {
-    xSeconds: (count) => `${count}sec`,
-    xMinutes: (count) => `${count}min`,
-    xHours: (count) => `${count}hour`,
+    xSeconds: (count) => `${count}s`,
+    xMinutes: (count) => `${count}m`,
+    xHours: (count) => `${count}h`,
   };
 
   const shortLocale = {

--- a/public/utils/dateFormat.js
+++ b/public/utils/dateFormat.js
@@ -1,0 +1,27 @@
+const { intervalToDuration, formatDuration } = require('date-fns');
+const formatDistanceStrict = require('date-fns/formatDistanceStrict');
+
+module.exports.getDistanceDate = (startDate, finishedDate) => {
+  const formatDistanceLocale = {
+    xSeconds: (count) => `${count}sec`,
+    xMinutes: (count) => `${count}min`,
+    xHours: (count) => `${count}hour`,
+  };
+
+  const shortLocale = {
+    formatDistance: (token, count) => formatDistanceLocale[token](count),
+  };
+
+  const seconds = parseInt(
+    formatDistanceStrict(new Date(startDate), new Date(finishedDate), {
+      unit: 'second',
+    }),
+  );
+  const duration = intervalToDuration({ start: 0, end: seconds * 1000 });
+  const distance = formatDuration(duration, {
+    format: ['hours', 'minutes', 'seconds'],
+    locale: shortLocale,
+  });
+
+  return distance;
+};

--- a/public/utils/extensions-manager.js
+++ b/public/utils/extensions-manager.js
@@ -1,0 +1,13 @@
+const devtoolsInstaller = require('electron-devtools-installer');
+
+class ExtensionsManager {
+  async init() {
+    const extensions = ['REACT_DEVELOPER_TOOLS'];
+
+    return Promise.all(
+      extensions.map((name) => devtoolsInstaller.default(devtoolsInstaller[name])),
+    );
+  }
+}
+
+module.exports.extensionsManager = new ExtensionsManager();

--- a/public/utils/ipc-manager.js
+++ b/public/utils/ipc-manager.js
@@ -1,0 +1,70 @@
+const { ipcMain } = require('electron');
+const activeWin = require('active-win');
+const { storeAppIcon } = require('./icon');
+const { trackWindowStore } = require('../store/TrackWindowStore.js');
+
+const activeWinActions = {
+  SELECTEDDAY_WINDOW: (event, payload) => {
+    trackWindowStore.setSelectedDay(payload);
+
+    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+    event.reply('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
+  },
+  ACTIVE_WINDOW: async (event) => {
+    const window = await activeWin({ screenRecordingPermission: true });
+    const {
+      id,
+      title,
+      url,
+      owner: { name, processId, path },
+    } = window;
+
+    const newActiveWin = {
+      id,
+      title,
+      processId,
+      name,
+      url: url,
+      startDate: new Date(),
+    };
+
+    storeAppIcon(name, path); // 앱 아이콘 저장
+
+    trackWindowStore.getStore();
+
+    if (trackWindowStore.isNewTrackWindow(newActiveWin)) {
+      if (trackWindowStore.hasCurrentWindow()) {
+        trackWindowStore.setCurrentActiveWinFinishedDate(newActiveWin.startDate);
+      }
+      trackWindowStore.setNewTrackWindow(newActiveWin);
+    }
+
+    if (trackWindowStore.isSelectedDayToday()) {
+      const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+      event.reply('REPLY_ACTIVE_WINDOW', { newActiveWin, allDayTrackWindows });
+    }
+  },
+  STOP_ACTIVE_WINDOW: (event) => {
+    trackWindowStore.endTrackingWindow();
+
+    const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+    event.reply('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
+  },
+};
+
+class IPCManager {
+  init = () => {
+    Object.keys(activeWinActions).forEach((actionName) => {
+      ipcMain.on(actionName, async (...args) => {
+        try {
+          const result = activeWinActions[actionName](...args);
+          return result;
+        } catch (e) {
+          return { error: e.toString() };
+        }
+      });
+    });
+  };
+}
+
+module.exports.ipcManager = new IPCManager();

--- a/public/utils/ipc-manager.js
+++ b/public/utils/ipc-manager.js
@@ -30,8 +30,6 @@ const activeWinActions = {
 
     storeAppIcon(name, path); // 앱 아이콘 저장
 
-    trackWindowStore.getStore();
-
     if (trackWindowStore.isNewTrackWindow(newActiveWin)) {
       if (trackWindowStore.hasCurrentWindow()) {
         trackWindowStore.setCurrentActiveWinFinishedDate(newActiveWin.startDate);

--- a/public/utils/window-manager.js
+++ b/public/utils/window-manager.js
@@ -1,0 +1,39 @@
+const { BrowserWindow } = require('electron');
+const { join } = require('path');
+const path = require('path');
+const { trackWindowStore } = require('../store/TrackWindowStore');
+
+class WindowManager {
+  window;
+
+  createWindow = () => {
+    this.window = new BrowserWindow({
+      show: false,
+      width: 960,
+      height: 540,
+      webPreferences: {
+        enableRemoteModule: true,
+        preload: join(__dirname, '../preload.js'),
+      },
+    });
+    if (process.env.mode === 'dev') {
+      this.window.loadURL('http://localhost:3000');
+      this.window.webContents.openDevTools();
+    } else {
+      // this.mainWindowloadURL(`file://${path.join(__dirname, '../build/index.html')}`)
+      this.window.loadFile(`${path.join(__dirname, '../build/index.html')}`);
+    }
+
+    this.window.once('ready-to-show', () => this.window.show());
+    this.window.on('closed', () => {
+      this.window = null;
+    });
+
+    this.window.webContents.on('did-finish-load', () => {
+      const allDayTrackWindows = trackWindowStore.findTrackWindowBySelectedDay();
+      this.window.webContents.send('REPLY_ACTIVE_WINDOW', { allDayTrackWindows });
+    });
+  };
+}
+
+module.exports.windowManager = new WindowManager();

--- a/src/App.js
+++ b/src/App.js
@@ -8,18 +8,18 @@ const {
 
 function App() {
   let [isOnTracked, setIsOnTracked] = useState(false);
-  const [activeWindows, setActiveWindows] = useState([]);
+  const [allDayTrackWindows, setAllDayTrackWindows] = useState([]);
 
   useEffect(() => {
     onIpc('REPLY_ACTIVE_WINDOW', (event, payload) => {
-      console.log(payload.processedWindow);
-      console.table(payload.activeWindows);
-      setActiveWindows(payload.activeWindows);
+      console.log(payload.newActiveWin);
+      console.table(payload.allDayTrackWindows);
+      setAllDayTrackWindows(payload.allDayTrackWindows);
     });
     return () => {
       removeIpc('REPLY_ACTIVE_WINDOW');
     };
-  }, [activeWindows]);
+  }, [allDayTrackWindows]);
 
   useInterval(
     () => {
@@ -35,7 +35,7 @@ function App() {
         name="check-it-out"
         isOnTracked={isOnTracked}
         setIsOnTracked={setIsOnTracked}></Toolbar>
-      <ProgramTable programList={activeWindows}></ProgramTable>
+      <ProgramTable programList={allDayTrackWindows}></ProgramTable>
     </div>
   );
 }

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,10 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import { format } from 'date-fns';
 import { Button, ButtonGroup, Card, Divider } from '@mui/material';
 import MuiGrid from '@mui/material/Grid';
 import { styled } from '@mui/material/styles';
 import { PlayArrow, Pause, ArrowForwardIos } from '@mui/icons-material';
 import { ArrowBackIosNew } from '@mui/icons-material';
 import { useInterval } from '../hooks/intervalHooks.js';
+
+const {
+  electronBridge: { sendIpc, onIpc },
+} = window;
 
 const Grid = styled(MuiGrid)(({ theme }) => ({
   width: '100%',
@@ -92,14 +97,6 @@ function Toolbar({ isOnTracked, setIsOnTracked }) {
   //let [isOnTracked, setIsOnTracked] = useState(false);
   let [selectedDay, setSelectedDay] = useState(new Date());
 
-  useEffect(() => {
-    console.log('useEffect');
-
-    return function cleanup() {
-      console.log('cleanup');
-    };
-  });
-
   useInterval(
     () => {
       setWorkingTime(workingTime + 1);
@@ -125,6 +122,8 @@ function Toolbar({ isOnTracked, setIsOnTracked }) {
     selectedDay.setDate(
       action === 'GO_YESTERDAY' ? selectedDay.getDate() - 1 : selectedDay.getDate() + 1,
     );
+    //* selectedDay에 맞는 데이터를 electron-store에서 가져오기
+    sendIpc('SELECTEDDAY_WINDOW', format(selectedDay, 'yyyy-MM-dd'));
     setSelectedDay(new Date(selectedDay));
   }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -8,7 +8,7 @@ import { ArrowBackIosNew } from '@mui/icons-material';
 import { useInterval } from '../hooks/intervalHooks.js';
 
 const {
-  electronBridge: { sendIpc, onIpc },
+  electronBridge: { sendIpc },
 } = window;
 
 const Grid = styled(MuiGrid)(({ theme }) => ({
@@ -36,6 +36,15 @@ const SelectDayButton = (props) => {
         <ArrowForwardIos sx={{ fontSize: 15 }} />
       </Button>
     </ButtonGroup>
+  );
+};
+
+const TodayButton = (props) => {
+  const { handleTodayButtonClick } = props;
+  return (
+    <Button variant="contained" onClick={handleTodayButtonClick} color={'success'}>
+      TODAY
+    </Button>
   );
 };
 
@@ -122,6 +131,16 @@ function Toolbar({ isOnTracked, setIsOnTracked }) {
     selectDayByClicked('GO_TOMORROW');
   }
 
+  function handleTodayButtonClick() {
+    const selectedDayFormat = format(new Date(selectedDay), 'yyyy-MM-dd');
+    const todayFormat = format(new Date(), 'yyyy-MM-dd');
+
+    if (selectedDayFormat !== todayFormat) {
+      sendIpc('SELECTEDDAY_WINDOW', todayFormat);
+      setSelectedDay(new Date());
+    }
+  }
+
   function selectDayByClicked(action) {
     selectedDay.setDate(
       action === 'GO_YESTERDAY' ? selectedDay.getDate() - 1 : selectedDay.getDate() + 1,
@@ -139,6 +158,7 @@ function Toolbar({ isOnTracked, setIsOnTracked }) {
             selectedDay={selectedDay}
             handleLeftArrowButtonClick={handleLeftArrowButtonClick}
             handleRightArrowButtonClick={handleRightArrowButtonClick}></SelectDayButton>
+          <TodayButton handleTodayButtonClick={handleTodayButtonClick}></TodayButton>
         </Grid>
         <Grid item xs={6} sx={{ p: 0, display: 'flex', justifyContent: 'flex-end' }}>
           <Timer handleTrackButtonClick={handleTrackButtonClick} isOnTracked={isOnTracked} />

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -42,7 +42,7 @@ const SelectDayButton = (props) => {
 const TodayButton = (props) => {
   const { handleTodayButtonClick } = props;
   return (
-    <Button variant="contained" onClick={handleTodayButtonClick} color={'success'}>
+    <Button variant="contained" onClick={handleTodayButtonClick} color={'success'} sx={{ ml: 1 }}>
       TODAY
     </Button>
   );

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -108,6 +108,10 @@ function Toolbar({ isOnTracked, setIsOnTracked }) {
     setStart(isOnTracked ? start : new Date().toLocaleString());
     setFinish(isOnTracked ? new Date().toLocaleString() : '작업중');
     setIsOnTracked(!isOnTracked);
+
+    if (isOnTracked) {
+      sendIpc('STOP_ACTIVE_WINDOW');
+    }
   }
 
   function handleLeftArrowButtonClick() {


### PR DESCRIPTION
- electron-store를 이용하여 데이터 관리하기
- 화살표 버튼(`<`, `>`)으로 날짜 이동하여 해당 날짜에 기록된 데이터 가져오기
- 다른 프로그램으로 포커스가 이동한 경우(= 활성화된 프로그램이 변경된 경우)를 확인할 조건 변경 : app.id와 app.title이 다르면 새로운 프로그램으로 간주
  - 예) Chrome을 실행중이어도 탭을 이동하면 새로운 프로그램으로 간주하여 해당 active-win 정보를 저장
- (1)_앱이 종료되거나_ (2)_추적 시작/종료 버튼을 클릭한 경우_ 현재 활성화된 프로그램의 종료 시간과 활성 시간을 계산해 저장소에 업데이트 처리
- 오늘 기록된 데이터를 가져올 `TODAY` 버튼 생성
- 앱 최초 실행 시 저장소에 있는 데이터 가져오기

fix #4 